### PR TITLE
add links to meeting notes + update next meeting location

### DIFF
--- a/_posts/2016-05-22-last_meetings.md
+++ b/_posts/2016-05-22-last_meetings.md
@@ -6,6 +6,8 @@ fa-icon: users
 ---
 
 # Past meetings
+- [26th. MXCuBE meeting organized by Diamond and GPHL, 17-19.11.2025](doc/past_meetings/2025_dls/index.html)
+- 25th. MXCuBE meeting organized by EMBL Hamburg and DESY, 19-21.05.2025
 - [24th. MXCuBE meeting organized by Elettra, 20-22.11.2024](doc/past_meetings/2024_elettra/index.html)
 - [23rd. MXCuBE meeting organized by MAXIV, 28-31.05.2024](doc/past_meetings/2024_max_lab/index.html)
 - [22nd. MXCuBE meeting organized by ALBA, 28-30.11.2023](doc/past_meetings/2023_alba/index.html)

--- a/_posts/2017-01-16-next_meeting.md
+++ b/_posts/2017-01-16-next_meeting.md
@@ -5,4 +5,4 @@ color: white
 fa-icon: users 
 ---
 
-# Next MXCuBE meeting organized by EMBL Hamburg and DESY, Spring 2025
+# Next MXCuBE meeting organized by HZB, Spring 2026


### PR DESCRIPTION
This adds the missing link to the meeting notes from the last meeting at Diamond and updates the website next meeting location to be in Berlin